### PR TITLE
Internetless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+ARG GOVC_VERSION=v0.20.0
+
+FROM ubuntu AS build
+RUN apt-get update && apt-get -y install curl && rm -rf /var/cache/apt/*
+RUN curl -L https://github.com/vmware/govmomi/releases/download/${GOVC_VERSION:-v0.20.0}/govc_linux_amd64.gz | gunzip > /usr/local/bin/govc && chmod +x /usr/local/bin/govc
+
+FROM ubuntu
+COPY --from=build /usr/local/bin/govc /usr/local/bin/govc

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The stembuild cli expects the VM to be in a specific state. To get there, follow
 1. The pipeline has options of where things can be stored. Specifically S3 compatible, Google Cloud, or Azure store. The default is S3 compatible. If you would like to use a different store just comment/uncomment things in `pipeline.yml`.
 
 1. The `vars.yml` file will feed variables to the pipeline. Fill in the values appropriatly.
-  
+
     *Vcenter certificate*
-    
-    The CA certs for vcenter are not optional. You can retrieve the cert by following [this vmware doc](https://pubs.vmware.com/vsphere-6-5/index.jsp?topic=%2Fcom.vmware.vcli.getstart.doc%2FGUID-9AF8E0A7-1A64-4839-AB97-2F18D8ECB9FE.html). 
+
+    The CA certs for vcenter are not optional. You can retrieve the cert by following [this vmware doc](https://pubs.vmware.com/vsphere-6-5/index.jsp?topic=%2Fcom.vmware.vcli.getstart.doc%2FGUID-9AF8E0A7-1A64-4839-AB97-2F18D8ECB9FE.html).
 
 1. Using the [fly cli](https://concourse-ci.org/fly.html), [login](https://concourse-ci.org/fly.html#fly-login) to concourse, and [set](https://concourse-ci.org/setting-pipelines.html#fly-set-pipeline) the pipeline with variables filled.
 

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -9,7 +9,7 @@ resource_types:
   type: docker-image
   source:
     repository: frodenas/gcs-resource
-    
+
 - name: azure-blobstore
   type: docker-image
   source:
@@ -19,7 +19,11 @@ resources:
 - name: ubuntu-image
   type: docker-image
   source: { repository: ubuntu }
-  
+
+- name: govc-image
+  type: docker-image
+  source: { repository: ubuntu }
+
 - name: pipeline-tasks
   type: git
   source:
@@ -27,6 +31,28 @@ resources:
     branch: master
     username: ((tasks.username))
     password: ((tasks.password))
+    paths:
+    - tasks/*
+    # - Dockerfile  # Only needed if using build-image task option#2
+
+# Only need if using govc as resource from s3 (govc option#3b)
+# - name: govc
+#   type: s3
+#   source:
+#     access_key_id: ((s3.access_key_id))
+#     bucket: ((s3.bucket.lgpo))
+#     secret_access_key: ((s3.secret_access_key))
+#     endpoint: ((s3.endpoint))
+#     versioned_file: govc_linux_amd64.gz
+#     #regexp: 0.0.(.*)/govc_linux_amd64.gz
+
+# Only need if using govc as resource from github
+# - name: govc
+#   type: github-release
+#   source:
+#     repository: vmware
+#     owner: govmomi
+#     access_token: ((github_access_token))
 
 - name: stembuild-release
   type: pivnet
@@ -102,12 +128,25 @@ jobs:
       params:
         globs:
           - stembuild-linux-*
+    # Only needed if using govc as resource
+    # - get: govc
+    # Only needed if using build-image task
+    # - task: build-image
+    #   file: pipeline-tasks/tasks/build-image.yml
+    #   privileged: true  # builder-task requires privilege
+    #   input_mapping:
+    #     context: pipeline-tasks
+
     - task: construct
       file: pipeline-tasks/tasks/construct.yml
       image: ubuntu-image
+      # Only needed if using build-image task
+      # image: rootfs
       input_mapping:
         stembuild: stembuild-release
         lgpo: lgpo
+        # Only needed if using govc as resource
+        # govc: govc
       params:
         vcenter_ca_certs: ((vcenter-ca-certs))
         vcenter_url: ((vcenter-url))

--- a/tasks/build-image.yml
+++ b/tasks/build-image.yml
@@ -1,0 +1,26 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: concourse/builder-task
+    tag: latest
+
+inputs:
+- name: context
+
+outputs:
+- name: image
+- name: rootfs # The directory to store the contents of the image for use in later tasks
+
+caches:
+- path: cache
+
+params:
+  REPOSITORY: stembuild-image
+  CONTEXT: context
+  BUILD_ARG_GOVC_VERSION:  # Sets the govc version to download
+
+run:
+  path: build

--- a/tasks/construct.yml
+++ b/tasks/construct.yml
@@ -4,6 +4,8 @@ platform: linux
 inputs:
 - name: stembuild # contains the state for the vm
 - name: lgpo # contains the product configuration file
+- name: govc # contains govc cli
+  optional: true
 
 params:
   vcenter_ca_certs: ((vcenter-ca-certs))
@@ -14,7 +16,7 @@ params:
   vm_ip: ((vm-ip))
   vm_password: ((vm-password))
   vm_username: ((vm-username))
-  
+
 run:
   path: bash
   args:
@@ -41,7 +43,7 @@ run:
       ls -al lgpo
       exit 1
     fi
-    
+
     #LGPO needs to be in the working folder (where stembuild is called fom)
     cp lgpo/LGPO.zip ./LGPO.zip
 
@@ -49,6 +51,28 @@ run:
       echo "LGPO needs to be in working dir."
       echo "Contents of current dir:"
       ls -al
+      exit 1
+    fi
+
+    # Check for the govc cli
+    if hash govc; then
+      GOVC_CLI=govc
+    else
+      GOVC_CLI="$(find govc/govc_linux_* 2>/dev/null | head -n1)"
+      if [[ -z "$GOVC_CLI" ]]; then
+        # TODO: Remove
+        # Fallback to download
+        apt-get update && apt-get -y install curl
+        curl -L https://github.com/vmware/govmomi/releases/download/v0.20.0/govc_linux_amd64.gz | gunzip > /usr/local/bin/govc
+        chmod +x /usr/local/bin/govc
+        GOVC_CLI=/usr/local/bin/govc
+      fi
+    fi
+
+    if [[ -z "$GOVC_CLI" ]]; then
+      echo "GOVC cli could not be found.  Please change docker imge to one with govc OR add govc as input."
+      echo "Contents of govc dir:"
+      ls -al govc
       exit 1
     fi
 
@@ -73,10 +97,6 @@ run:
 
     #Once the construct process exits, the VM is still doing work. We will know it's done with it shuts off. The following will download the govc cli and poll the VM for it's power status.
 
-    apt-get update && apt-get -y install curl
-    curl -L https://github.com/vmware/govmomi/releases/download/v0.20.0/govc_linux_amd64.gz | gunzip > /usr/local/bin/govc
-    chmod +x /usr/local/bin/govc
-
     export GOVC_URL=${vcenter_url}
     export GOVC_USERNAME=${vcenter_username}
     export GOVC_PASSWORD=${vcenter_password}
@@ -84,7 +104,7 @@ run:
     #export GOVC_INSECURE=0
 
     #wait for VM to shut off
-     while [[ $(echo $(govc vm.info -vm.ipath=${vm_inventory_path} | grep 'Power state:')) = "Power state: poweredOn"  ]]; do
+     while [[ $(echo $($GOVC_CLI vm.info -vm.ipath=${vm_inventory_path} | grep 'Power state:')) = "Power state: poweredOn"  ]]; do
       sleep 2m
     done
 


### PR DESCRIPTION
# Issue
The current construct script pulls from Github.  This is not sufficient for organizations which cannot pull from Github let alone the internet.

## Proposed Solutions
I have included two commits:
1. The change to the task file.  It can accomodate all of these scenarios.
1. The many changes to the yaml file, adding a dockerfile, and an extra task

### Option 1: Have consumers build the image themselves
I have included a blueprint for adding the [builder-task](https://github.com/concourse/builder-task) which is a docker image distributed by concourse to build a docker image within a pipeline and use it in a further task.

* Pros:
  - Uses an already existing docker image

* Cons:
  - Makes the pipeline harder to read

* Further improvements:
  - Store the docker image in an s3 bucket

### Option 2: Provide a docker image.
I have included a Dockerfile.  Instead of having a step to build the docker image and passing the rootfs output, an official docker-image could be distributed.  Some consumers require *official* support to use these kind of images.

* Pros:
  - Easily distributable

* Cons:
  - Requires heavier maintenance

### Option 3: Create govc resource
Download the govc resource via s3 bucket or github-release with the prior being more likely since consumers may not have access to the Github let alone the internet.  However, consumers with internal Github could still easily modify the pipeline to pull the release from their internal github.

#### a. S3 version:
```yaml
# under resources
- name: govc
  type: s3
  source:
    access_key_id: ((s3.access_key_id))
    bucket: ((s3.bucket.lgpo))
    secret_access_key: ((s3.secret_access_key))
    endpoint: ((s3.endpoint))
    versioned_file: govc_linux_amd64.gz
    #regexp: 0.0.(.*)/govc_linux_amd64.gz
```

* Pros:
  - Follows existing s3 assumptions

* Cons:
  - Requires extra pre-req

#### b. Github Release version:
```yaml
# under resources
- name: govc
  type: github-release
  source:
    access_token: ((github_token))
    owner: vmware
    repository: govmomi
```

* Pros:
  - Keeps up-to-date

* Cons:
  - Currently there is no unpack option in github-release-resource: See [Issue #73](https://github.com/concourse/github-release-resource/issues/73)

Workaround:
1. Change `govc` resource name to `govc`
1. Add the following task:
```yaml
- task: unpack-govc
  image: ubuntu-image
  config:
    platform: linux
    inputs:
      - name: archive
    outputs:
      - name: unpacked
    run:
      path: bash
      args:
        - "-c"
        - |
          file=archive/*.gz
          gunzip $file > unpacked/$(basename $file .gz)
  input_mapping:
    archive: govc-release
  output_mappging:
    unpacked: govc
```
